### PR TITLE
Remove trailing comma

### DIFF
--- a/DistZilla.sublime-build
+++ b/DistZilla.sublime-build
@@ -64,6 +64,6 @@
         {
             "name": "DistZilla Test (test your dist)",
             "cmd": ["dzil", "test"]
-        },
+        }
     ]
 }


### PR DESCRIPTION
Fixes "Error trying to parse build system: Trailing comma before closing bracket in ~/Library/Application Support/Sublime Text 2/Packages/DistZilla Build/DistZilla.sublime-build:68:5"
